### PR TITLE
fix(ATLAS parser): fix publisher field. specify tid in publisher

### DIFF
--- a/survey_parser_plugins/parsers/ATLASParser.py
+++ b/survey_parser_plugins/parsers/ATLASParser.py
@@ -42,7 +42,7 @@ class ATLASParser(SurveyParser):
 
             # inclusion of extra attributes
             generic_alert_message['oid'] = oid
-            generic_alert_message['tid'] = cls._source # This must be more exact (for telescopes)
+            generic_alert_message['tid'] = message["publisher"]
             generic_alert_message['aid'] = oid
             generic_alert_message['fid'] = cls._fid_mapper[candidate["filter"]]
             # inclusion of stamps


### PR DESCRIPTION
In the ATLAS survey, the telescope can change. For example, ATLAS-01a and ATLAS-01b.

This small change allows the use of the `publisher` field to be used as a telescope ID.